### PR TITLE
Fix reading options plist

### DIFF
--- a/code/nice-org-html.el
+++ b/code/nice-org-html.el
@@ -514,7 +514,7 @@ See docs for `org-html-export-to-html', which this function emulates."
 		       nice-org-html-js nil nil nil))
 	 (nice-org-html-options
 	  (funcall convert (read-string "Options plist (optional): "
-				  nice-org-html-options nil nil nil)))
+			      (prin1-to-string nice-org-html-options) nil nil nil)))
 	 (extension (concat
 		     (when (> (length org-html-extension) 0) ".")
 		     (or (plist-get ext-plist :html-extension)


### PR DESCRIPTION
Ran into this problem while playing with the new `src-lang` option 🙃.

If `nice-org-html-options` is set to a plist, `read-string` will complain. Converting it to a string with `prin1-to-string` first seemed to fix the issue for me. Not sure if there's a better approach though.